### PR TITLE
Added !goerlieth Command for FAQ Response

### DIFF
--- a/prysmbot/main.go
+++ b/prysmbot/main.go
@@ -133,7 +133,7 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 	}
 
 	if fullCommand == "goerlieth" {
-		_, err := s.ChannelMessageSend(m.ChannelID, "Our goerli bot is currently disabled due to bot abuse if you're looking to setup a testnet validator we'd recommend going to the ethstaker discord and using their bot to make the testnet deposit. https://discord.io/ethstaker")
+		_, err := s.ChannelMessageSend(m.ChannelID, "Our goerli bot is currently disabled due to bot abuse if you're looking to setup a testnet validator we'd recommend going to the ethstaker discord and using their bot to make the testnet deposit.\nhttps://discord.io/ethstaker")
 		if err != nil {
 			log.WithError(err).Errorf("Error sending embed %s", fullCommand)
 		}

--- a/prysmbot/main.go
+++ b/prysmbot/main.go
@@ -131,6 +131,15 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 		}
 		return
 	}
+
+	if fullCommand == "goerlieth" {
+		_, err := s.ChannelMessageSend(m.ChannelID, "Our goerli bot is currently disabled due to bot abuse if you're looking to setup a testnet validator we'd recommend going to the ethstaker discord and using their bot to make the testnet deposit. https://discord.io/ethstaker")
+		if err != nil {
+			log.WithError(err).Errorf("Error sending embed %s", fullCommand)
+		}
+		return
+	}
+
 	if fullCommand == "help" && helpOkayChannel(m.ChannelID) {
 		embed := fullHelpEmbed()
 		_, err := s.ChannelMessageSendEmbed(m.ChannelID, embed)


### PR DESCRIPTION
This PR adds a simple response command to the bot explaining the current situation of the #request-goerli-eth channel and where users can go to make the deposit for their testnet validator(s).