### PR TITLE
Fix bot unverified auto-kick

### DIFF
--- a/prysmbot/constants.go
+++ b/prysmbot/constants.go
@@ -3,7 +3,7 @@ package main
 import "time"
 
 var (
-	maxUsersRetrieved = 20000
+	maxUsersRetrieved = 1000
 	maxTimeUnverified = time.Minute * 10
 
 	// Channels and server ids.


### PR DESCRIPTION
Changes:
- Set max return limit to 1000 (max API allowed)
- Add additional debug logging
- Reduce kick check interval to 1 minute (from 10 minutes)
- Add warning if number of returned users is equal to the max. This would indicate that the constant fetchGuildMembersAfterId would need to be increased.
