### PR TITLE
Add subcommand support for CLI configuration guide

### DIFF
--- a/tools/cli-help-api/flags.json
+++ b/tools/cli-help-api/flags.json
@@ -1,0 +1,40 @@
+[{
+    "validator": {
+        "options": [
+            {
+                "wallet": {
+                    "subcommand":"create,edit-config,recover"
+                }
+            },
+            {
+                "accounts": {
+                    "subcommand":"delete,list,backup,import,voluntary-exit"
+                }
+            },
+            {
+                "slashing-protection-history": {
+                    "subcommand":"export,import"
+                }
+            },
+            {
+                "db": {
+                    "subcommand":"restore"
+                }
+            },
+            {
+                "web": {
+                    "subcommand":"generate-auth-token"
+                }
+            }
+        ]
+    },
+	"beacon-chain": {
+        "options": [
+            {
+                "db": {
+                    "subcommand":"restore"
+                }
+            }
+        ]
+    }
+}]


### PR DESCRIPTION
This PR is a proposal to fix [Prysm Issue #10131](https://github.com/prysmaticlabs/prysm/issues/10131). I'm new to open source contributions and Golang, so any/all suggestions are welcome.

To add support for subcommands, a file named `flags.json` was created to include each component's options and corresponding subcommand. The rationale being that if options or subcommands are added/removed in the future, this file can be edited to reflect that. I wasn't able to think of a way to automatically download the latest subcommands without being too complicated. 

The function `getSubcommands` utilizes structs that define this json file to iterate over the available options and subcommands per component (Validator and BeaconChain).

Thank you for your time in reviewing this pull request.