### PR TITLE
Use debian instead of alpine for cli help

### DIFF
--- a/tools/cli-help-api/Dockerfile
+++ b/tools/cli-help-api/Dockerfile
@@ -1,16 +1,11 @@
 # Accept the Go version for the image to be set as a build argument.
-ARG GO_VERSION=1.16
+ARG GO_VERSION=1.18
 
-FROM golang:${GO_VERSION}-alpine
+FROM golang:${GO_VERSION}-bullseye
 
 # Git is required for fetching the dependencies.
-RUN apk update
-RUN apk upgrade
-RUN apk add --no-cache git
-RUN apk add ca-certificates
-RUN apk add libc6-compat
-RUN apk add libgcc
-RUN apk add libstdc++
+RUN apt-get update && apt-get -y upgrade
+RUN apt-get install -y git
 
 # Set the working directory outside $GOPATH to enable the support for modules.
 WORKDIR /src


### PR DESCRIPTION
Fixes 

```
Error relocating /data/validator-v2.1.3-linux-amd64: __memcpy_chk: symbol not found
Error relocating /data/validator-v2.1.3-linux-amd64: __memset_chk: symbol not found
exit status 127
```
