### PR TITLE
Fix GetForkChoice API Url

### DIFF
--- a/events-monitor/main.go
+++ b/events-monitor/main.go
@@ -23,7 +23,7 @@ import (
 const emailSlotsPerReorg = 32 // If we receive a reorg event, for the next 32 slots, email a forkchoice dump.
 
 var (
-	forkchoiceDebugMethod = "/eth/v1/debug/beacon/forkchoice"
+	forkchoiceDebugMethod = "/eth/v1/debug/forkchoice"
 	monitorFlags          = struct {
 		beaconEndpoint   string
 		httpEndpoint     string


### PR DESCRIPTION
This fixes our url to be updated to that of prysm v3.2.0. All requests for forkchoice data were failing in our infra due to using the outdated url.