### PR TITLE
Bring Back Forkchoice Dumps and HTTP Status Checks

### DIFF
--- a/events-monitor/main.go
+++ b/events-monitor/main.go
@@ -25,7 +25,7 @@ import (
 const emailSlotsPerReorg = 32 // If we receive a reorg event, for the next 32 slots, email a forkchoice dump.
 
 var (
-	forkchoiceDebugMethod = "/eth/v1/debug/forkchoice"
+	forkchoiceDebugMethod = "/eth/v1/debug/fork_choice"
 	monitorFlags          = struct {
 		beaconEndpoint     string
 		fluentd            bool

--- a/events-monitor/main.go
+++ b/events-monitor/main.go
@@ -247,8 +247,8 @@ func writeForkchoiceDump(ctx context.Context, storageClient *storage.Client) err
 		return err
 	}
 	if resp.StatusCode != http.StatusOK {
-		log.Error("Request to URL: %s", url)
-		log.Error("Response: %+v", resp)
+		log.Errorf("Request to URL: %s", url)
+		log.Errorf("Response: %+v", resp)
 		return fmt.Errorf("did not receive OK HTTP status: %d", resp.StatusCode)
 	}
 	defer func() {

--- a/events-monitor/main.go
+++ b/events-monitor/main.go
@@ -241,11 +241,14 @@ func storeForkchoiceDumps(ctx context.Context, storageClient *storage.Client) {
 func writeForkchoiceDump(ctx context.Context, storageClient *storage.Client) error {
 	log.Info("Attempting to write forkchoice dump")
 	var forkchoiceDump map[string]interface{}
-	resp, err := http.Get(monitorFlags.httpEndpoint + forkchoiceDebugMethod)
+	url := monitorFlags.httpEndpoint + forkchoiceDebugMethod
+	resp, err := http.Get(url)
 	if err != nil {
 		return err
 	}
 	if resp.StatusCode != http.StatusOK {
+		log.Error("Request to URL: %s", url)
+		log.Error("Response: %+v", resp)
 		return fmt.Errorf("did not receive OK HTTP status: %d", resp.StatusCode)
 	}
 	defer func() {

--- a/events-monitor/main.go
+++ b/events-monitor/main.go
@@ -70,12 +70,6 @@ func main() {
 				Value:       time.Minute * 5,
 				Usage:       "Interval to store forkchoice dumps (default 5m)",
 			},
-			&cli.DurationFlag{
-				Name:        "purge-dumps-after",
-				Destination: &monitorFlags.purgeDumpsInterval,
-				Value:       time.Hour * 48,
-				Usage:       "Interval to purge forkchoice dumps (default 48h)",
-			},
 			&cli.StringSliceFlag{
 				Name:        "topics",
 				Destination: &monitorFlags.topics,


### PR DESCRIPTION
This PR brings back forkchoice dump fetching and checks the http status codes of retrieving them from a node via JSON-RPC